### PR TITLE
update babel-core to 6.25.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "babel-code-frame": "~6.7.4",
-    "babel-core": "~6.7.4",
+    "babel-core": "^6.25.0",
     "babel-helper-define-map": "~6.6.5",
     "babel-helper-function-name": "~6.6.0",
     "babel-helper-get-function-arity": "~6.6.5",


### PR DESCRIPTION
This addresses the following vulnerability:

https://snyk.io/vuln/npm:minimatch:20160620